### PR TITLE
feat: provide pyproject.toml with black configuration

### DIFF
--- a/plaster/run/call_bag.py
+++ b/plaster/run/call_bag.py
@@ -379,7 +379,9 @@ class CallBag:
         # EXTRACT training recalls from the subset of peps.
         # This will leave NANs for all those that are not in the subset.
         if self._sim_v1_result is not None:
-            filtered_pep_recalls = np.full_like(self._sim_v1_result.train_recalls, np.nan)
+            filtered_pep_recalls = np.full_like(
+                self._sim_v1_result.train_recalls, np.nan
+            )
             filtered_pep_recalls[pep_iz_subset] = self._sim_v1_result.train_recalls[
                 pep_iz_subset
             ]
@@ -524,7 +526,9 @@ class CallBag:
         # EXTRACT training recalls from the subset of peps.
         # This will leave NANs for all those that are not in the subset.
         if self._sim_v1_result is not None:
-            filtered_pep_recalls = np.full_like(self._sim_v1_result.train_recalls, np.nan)
+            filtered_pep_recalls = np.full_like(
+                self._sim_v1_result.train_recalls, np.nan
+            )
             filtered_pep_recalls[pep_iz_subset] = self._sim_v1_result.train_recalls[
                 pep_iz_subset
             ]

--- a/plaster/run/sim_v1/sim_v1_task.py
+++ b/plaster/run/sim_v1/sim_v1_task.py
@@ -11,6 +11,8 @@ class SimV1Task(PipelineTask):
 
         prep_result = PrepResult.load_from_folder(self.inputs.prep)
 
-        sim_result = sim_v1(sim_params, prep_result, progress=self.progress, pipeline=self)
+        sim_result = sim_v1(
+            sim_params, prep_result, progress=self.progress, pipeline=self
+        )
         sim_result._generate_flu_info(prep_result)
         sim_result.save()

--- a/plaster/run/sim_v2/zests/zest_sim_v2_pyx.py
+++ b/plaster/run/sim_v2/zests/zest_sim_v2_pyx.py
@@ -28,7 +28,11 @@ def zest_pyx_runs():
     pep_seq_df = pd.read_csv(StringIO(csv))
 
     labelled_pep_df = pd.merge(
-        left=pep_seq_df, right=sim_params.df, left_on="aa", right_on="amino_acid", how="left"
+        left=pep_seq_df,
+        right=sim_params.df,
+        left_on="aa",
+        right_on="amino_acid",
+        how="left",
     )
 
     flus = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+# used this way black works in CI and in dev
+# refer to https://github.com/psf/black#configuration-format
+[tool.black]
+include = '\.pyi?$'
+exclude = "/vendor/"

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 from setuptools import Extension, setup, dist
 import pathlib
 
-dist.Distribution().fetch_build_eggs(['Cython>=0.15.1', 'numpy>=1.10'])
+dist.Distribution().fetch_build_eggs(["Cython>=0.15.1", "numpy>=1.10"])
 
 from Cython.Build import cythonize
 import numpy


### PR DESCRIPTION
@zack-erisyon this changes the way that black is provided its exclusions. The benefit of this approach is that it works with both CI and the way we call black in our dev flow. I expect in the next week or so I'll have the pre-commit CI hooks in place, which make use of this also.