### PR TITLE
feat(schema): pass message from t() -> CheckError

### DIFF
--- a/plaster/tools/log/log.py
+++ b/plaster/tools/log/log.py
@@ -185,7 +185,7 @@ def metrics(**kws):
 
 
 def exception(e, msg=""):
-    """See make_exception"""
+    """See _make_exception"""
     assert isinstance(e, Exception)
     prefix = _make_prefix(EXCEPTION, -3)
     lines = _make_exception(e, msg)

--- a/plaster/tools/schema/check.py
+++ b/plaster/tools/schema/check.py
@@ -5,15 +5,16 @@ Strict guidelines.
 
 """
 
-import pandas as pd
-import os
 import inspect
+import os
 import re
-from plaster.tools.log import log
-import numpy as np
-from typing import get_type_hints
-from functools import wraps
 from collections import Iterable
+from functools import wraps
+from typing import get_type_hints
+
+import numpy as np
+import pandas as pd
+from plaster.tools.log import log
 
 
 def _context(depth=2):
@@ -112,7 +113,7 @@ def affirm(condition, message=None, exp=CheckAffirmError):
         raise exp
 
 
-def t(instance, expected_type, depth=3):
+def t(instance, expected_type, depth=3, **kwargs):
     """
     Check that instance is of expected_type and produce a useful trace and raise if not.
 
@@ -130,7 +131,7 @@ def t(instance, expected_type, depth=3):
         expected_type = type(None)
 
     if not isinstance(instance, expected_type):
-        raise CheckError(expected_type, type(instance), depth)
+        raise CheckError(expected_type, type(instance), depth, **kwargs)
 
 
 def list_t(instance, expected_type):


### PR DESCRIPTION
`CheckError` takes a kwarg: `message` but it's not passed through when using `check.t()`. This fixes that.

Also a minor update to the doc for `log.exception()`; I spent a minute or so looking for `make_exception`..