### PR TITLE
feat: use `in` to check Content-Type header; return Munch if json

### DIFF
--- a/plaster/tools/utils/simple_http.py
+++ b/plaster/tools/utils/simple_http.py
@@ -3,6 +3,7 @@ import json
 import ssl
 from urllib.parse import urlsplit
 
+from munch import munchify
 from plaster.tools.log.log import error
 from retrying import retry as _retry
 
@@ -31,7 +32,7 @@ def http_method(
         Passes kwargs to the HTTP Connection Class
         Uses Content-Length if provided
         Encodes to UTF-8 if not application/octet-stream
-        Returns a dict from json.loads if application/json
+        Returns a Munch if application/json; see https://github.com/Infinidat/munch
         Returns str in any other cases
     """
 
@@ -91,10 +92,10 @@ def http_method(
     else:
         result = response.read()
 
-    if response.getheader("Content-Type") != "application/octet-stream":
+    if "application/octet-stream" not in response.getheader("Content-Type"):
         result = result.decode("utf-8")
 
-    if response.getheader("Content-Type") == "application/json":
-        result = json.loads(result)
+    if "application/json" in response.getheader("Content-Type"):
+        result = munchify(json.loads(result))
 
     return result


### PR DESCRIPTION
Two minor tweaks:

`tools.schema.check.t` now returns `True` if it doesn't error; this allows it to be used in tests ala: `assert check.t(var, type)`.

`simple_http.py`; your handling of the `Content-Type` header is a little off; so I updated that. Specifically content type can have a `charset` like: `application/json;charset=utf-8` - so the `in` check is more correct.

I also took the liberty of passing back a munch instead of just a dict. I ran a cursory test to ensure the munch doesn't do anything strange. 