### PR TITLE
tweak zest limits to avoid stochastic failures

### DIFF
--- a/plaster/run/sigproc_v2/sigproc_v2_worker.py
+++ b/plaster/run/sigproc_v2/sigproc_v2_worker.py
@@ -358,7 +358,7 @@ def _psf_estimate(im, locs, mea, keep_dist=8, threshold_abs=None, return_reasons
     from scipy.spatial.distance import cdist  # Defer slow import
 
     # Sanity check that background is removed
-    assert np.nanmedian(im) < 5.0
+    assert np.nanmedian(im) < 10.0
 
     n_locs = len(locs)
     dist = cdist(locs, locs, metric="euclidean")

--- a/plaster/run/sigproc_v2/zests/zest_sigproc_v2_calibration.py
+++ b/plaster/run/sigproc_v2/zests/zest_sigproc_v2_calibration.py
@@ -221,7 +221,7 @@ def zest_sigproc_v2_calibration():
                 continue
             fit_params, fit_variance = imops.fit_gauss2(reg_psfs[x, y])
             for fv in fit_variance:
-                assert fv < 0.001
+                assert fv < 0.01
             fit_params_sum += np.array(fit_params)
         assert blank_regions <= 2
         fit_params_mean = fit_params_sum / ((divs * divs) - blank_regions)
@@ -323,7 +323,7 @@ def zest_sigproc_v2_calibration():
                 continue
             fit_params, fit_variance = imops.fit_gauss2(reg_psfs[x, y])
             for fv in fit_variance:
-                assert fv < 0.001
+                assert fv < 0.01
             if (x < test_corner_width) and (y < test_corner_width):
                 divisor_test_corner += 1
                 fit_params_sum_test_corner += np.array(fit_params)


### PR DESCRIPTION
I ran the zests 20x consecutively after these tweaks, and no failures.  Of course, I did that previously, and this still came up.  But I also printed out the median background median value (the value which was failing), and saw that although it was often below 1, it was not that rare for it to be over 4, so the fact that we every once in a while got one over 5 to cause a failure was I guess not all that surprising, if you run the tests often enough.