### PR TITLE
use nn_v2 default for classifier in PR plot for job

### DIFF
--- a/plaster/gen/nb_templates/train_and_test_epilog_template.ipynb
+++ b/plaster/gen/nb_templates/train_and_test_epilog_template.ipynb
@@ -48,7 +48,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plots.plot_pr_for_job( job, _size=600 )"
+    "plots.plot_pr_for_job( job, _size=600, classifier=\"nn_v2\" )"
    ]
   },
   {

--- a/plaster/run/plots/plots.py
+++ b/plaster/run/plots/plots.py
@@ -680,7 +680,7 @@ def plot_pr_for_run(
             )
 
 
-def plot_pr_for_job(job, force_all_proteins=False, classifier="test_rf", **kwargs):
+def plot_pr_for_job(job, force_all_proteins=False, classifier="nn_v2", **kwargs):
     """
     Single plot containing relevant PR per run, with legend to indicate run.
 


### PR DESCRIPTION
Current default classifier when doing gen classify is nn_v2, but plot_pr_for_job has default of "test_rf", so leaving everything at default results in an error.  Change default classifier in plot fxn and nb to be nn_v2.