### PR TITLE
sim v2 handle low nbr pepts better

### DIFF
--- a/plaster/gen/nb_templates/train_and_test_epilog_template.ipynb
+++ b/plaster/gen/nb_templates/train_and_test_epilog_template.ipynb
@@ -90,7 +90,7 @@
     "precisions = PGEN_report_precisions\n",
     "n_falses = 2\n",
     "pep_false_df = pd.concat([\n",
-    "    job.all_dfs(lambda run:run.test_rf_call_bag().false_rates_all_peps__ptm_info(prec, n_falses, protein_of_interest_only=include_poi_only))\n",
+    "    job.all_dfs(lambda run:run.nn_v2_call_bag().false_rates_all_peps__ptm_info(prec, n_falses, protein_of_interest_only=include_poi_only))\n",
     "    for prec in precisions\n",
     "]).sort_values(by=sort,ascending=ascend).reset_index()[cols]\n",
     "\n",

--- a/plaster/run/sim_v2/fast/sim_v2_fast.pyx
+++ b/plaster/run/sim_v2/fast/sim_v2_fast.pyx
@@ -155,9 +155,11 @@ def sim(
         #n_channels_to_n_max_dyepep_per_pep = [0, 100, 100, 100, 250, 425]
         extra_factor = 1.2
         hash_factor = 1.5
-        n_max_dtrs = <c.Size>(extra_factor * 250 * n_peps + 1000)
+        # constant of 8000 here is ad-hoc, based on results where very small
+        # numbers of peptides would result in a table overflow error
+        n_max_dtrs = <c.Size>(extra_factor * 250 * n_peps + 8000)
         n_max_dtr_hash_recs = int(hash_factor * n_max_dtrs)
-        n_max_dyepeps = <c.Size>(extra_factor * 425 * n_peps)
+        n_max_dyepeps = <c.Size>(extra_factor * 425 * n_peps + 8000)
         n_max_dyepep_hash_recs = int(hash_factor * n_max_dyepeps)
         dtr_mb = n_max_dtrs * n_dtr_row_bytes / 1024**2
         dyepep_mb = n_max_dyepeps * sizeof(c.DyePepRec) / 1024**2


### PR DESCRIPTION
Zack you mentioned we should make a better way to calculate needed table buffer size for low nbr of peptides.  If you think now is the time for me to dig into that I could revisit this, otherwise I just bumped up the "slop" factor so that we don't get an error "Table overflow on dyepeps".