### PR TITLE
Zbs248/lmfit

### DIFF
--- a/plaster/run/sigproc_v2/sigproc_v2_worker.py
+++ b/plaster/run/sigproc_v2/sigproc_v2_worker.py
@@ -477,12 +477,16 @@ def _analyze_step_6c_peak_differencing(chcy_ims, locs, peak_mea):
 
                 com_before = imops.com(peak_im ** 2)
                 center_pixel = np.array(peak_im.shape) / 2
-                cy_peak_ims[cy_i] = imops.sub_pixel_shift(peak_im, center_pixel - com_before)
+                cy_peak_ims[cy_i] = imops.sub_pixel_shift(
+                    peak_im, center_pixel - com_before
+                )
                 cy_peak_shifts[cy_i] = center_pixel - com_before
 
             else:
                 # DIFFERENCE only if we didn't break out (all peaks were good)
-                peak_cy_diffs[loc_i, ch_i, :, :, :] = np.diff(cy_peak_ims, axis=0, prepend=0)
+                peak_cy_diffs[loc_i, ch_i, :, :, :] = np.diff(
+                    cy_peak_ims, axis=0, prepend=0
+                )
                 peak_cys[loc_i, ch_i, :, :, :] = cy_peak_ims
                 peak_shifts[loc_i, ch_i, :, :] = cy_peak_shifts
 
@@ -572,12 +576,24 @@ def _sigproc_analyze_field(chcy_ims, sigproc_v2_params, calib, psf_params=None):
     difmat = None
     picmat = None
     if sigproc_v2_params.run_peak_differencing:
-        difmat, picmat, sftmat = _analyze_step_6c_peak_differencing(chcy_ims, locs, sigproc_v2_params.peak_mea)
+        difmat, picmat, sftmat = _analyze_step_6c_peak_differencing(
+            chcy_ims, locs, sigproc_v2_params.peak_mea
+        )
 
     # Temporaily removed until a better metric can be found
     # keep_mask = _analyze_step_7_filter(radmat, sigproc_v2_params, calib)
 
-    return chcy_ims, locs, radmat, aln_offsets, aln_scores, fitmat, difmat, picmat, sftmat
+    return (
+        chcy_ims,
+        locs,
+        radmat,
+        aln_offsets,
+        aln_scores,
+        fitmat,
+        difmat,
+        picmat,
+        sftmat,
+    )
 
 
 def _do_sigproc_analyze_and_save_field(
@@ -593,9 +609,17 @@ def _do_sigproc_analyze_and_save_field(
     if sigproc_v2_params.run_fitter:
         psf_params = psf.psf_fit_gaussian(calib.psfs(0))
 
-    chcy_ims, locs, radmat, aln_offsets, aln_scores, fitmat, difmat, picmat, sftmat = _sigproc_analyze_field(
-        chcy_ims, sigproc_v2_params, calib, psf_params
-    )
+    (
+        chcy_ims,
+        locs,
+        radmat,
+        aln_offsets,
+        aln_scores,
+        fitmat,
+        difmat,
+        picmat,
+        sftmat,
+    ) = _sigproc_analyze_field(chcy_ims, sigproc_v2_params, calib, psf_params)
 
     mea = np.array([chcy_ims.shape[-1:]])
     if np.any(aln_offsets ** 2 > (mea * 0.1) ** 2):

--- a/plaster/run/sigproc_v2/synth.py
+++ b/plaster/run/sigproc_v2/synth.py
@@ -197,10 +197,8 @@ class PeaksModel(BaseSynthModel):
             [
                 loc
                 for loc in self.locs
-                if loc[0] > dist
-                and loc[0] < self.dim[0] - dist
-                and loc[1] > dist
-                and loc[1] < self.dim[1] - dist
+                if dist < loc[0] < self.dim[0] - dist
+                and dist < loc[1] < self.dim[1] - dist
             ]
         )
         return self

--- a/plaster/run/sigproc_v2/synth.py
+++ b/plaster/run/sigproc_v2/synth.py
@@ -206,13 +206,13 @@ class PeaksModel(BaseSynthModel):
 
 class PeaksModelGaussian(PeaksModel):
     def __init__(self, **kws):
+        self.mea = kws.pop("mea", 11)
         super().__init__(**kws)
         self.std = None
         self.std_x = None
         self.std_y = None
         self.z_scale = None  # (simulates z stage)
         self.z_center = None  # (simulates z stage)
-        self.mea = 11
 
     def z_function(self, z_scale, z_center):
         self.z_scale = z_scale

--- a/plaster/tools/gauss2d/gauss2d.py
+++ b/plaster/tools/gauss2d/gauss2d.py
@@ -1,0 +1,77 @@
+import ctypes
+import numpy as np
+from plumbum import local, FG
+
+
+_lib_gauss_2d = None
+
+# Set recompile to True to force recompile which is handy if debugging zbs.lmfits
+# Also, remember to create a symlink in internal/overloads like:
+# zbs.lmfits -> /Users/zack/git/zbs.lmfits/
+recompile = False
+
+
+def load_lib():
+    global _lib_gauss_2d
+    if _lib_gauss_2d is not None:
+        return _lib_gauss_2d
+
+    if recompile:
+        with local.env(DST_FOLDER=local.cwd, LEVMAR_FOLDER="/zbs.lmfits/levmar-2.6"):
+            with local.cwd("/erisyon/internal/overloads/zbs.lmfits"):
+                local["./build.sh"] & FG
+
+        lib = ctypes.CDLL("./liblmfits.so")
+    else:
+        lib = ctypes.CDLL("/zbs.lmfits/liblmfits.so")
+
+    # fit_gauss_2d()
+    lib.fit_gauss_2d.argtypes = [
+        np.ctypeslib.ndpointer(dtype=np.float64, ndim=1, flags="C_CONTIGUOUS"),
+        ctypes.c_int,
+        np.ctypeslib.ndpointer(dtype=np.float64, ndim=1, flags="C_CONTIGUOUS"),
+        np.ctypeslib.ndpointer(dtype=np.float64, ndim=1, flags="C_CONTIGUOUS"),
+        np.ctypeslib.ndpointer(dtype=np.float64, ndim=1, flags="C_CONTIGUOUS"),
+    ]
+    lib.fit_gauss_2d.restype = ctypes.c_int
+
+    # fit_gauss_2d_on_float_image()
+    lib.fit_gauss_2d_on_float_image.argtypes = [
+        np.ctypeslib.ndpointer(dtype=np.float32, ndim=2, flags="C_CONTIGUOUS"),
+        ctypes.c_int,
+        ctypes.c_int,
+        ctypes.c_int,
+        ctypes.c_int,
+        ctypes.c_int,
+        np.ctypeslib.ndpointer(dtype=np.float64, ndim=1, flags="C_CONTIGUOUS"),
+        np.ctypeslib.ndpointer(dtype=np.float64, ndim=1, flags="C_CONTIGUOUS"),
+        np.ctypeslib.ndpointer(dtype=np.float64, ndim=1, flags="C_CONTIGUOUS"),
+    ]
+    lib.fit_gauss_2d_on_float_image.restpye = ctypes.c_int
+
+    # fit_array_of_gauss_2d_on_float_image()
+    lib.fit_array_of_gauss_2d_on_float_image.argtypes = [
+        np.ctypeslib.ndpointer(
+            dtype=np.float32, ndim=2, flags="C_CONTIGUOUS"
+        ),  # np_float32 *im
+        ctypes.c_int,  # np_int64 im_h
+        ctypes.c_int,  # np_int64 im_w
+        ctypes.c_int,  # np_int64 mea
+        ctypes.c_int,  # np_int64 n_peaks
+        np.ctypeslib.ndpointer(
+            dtype=np.int64, ndim=1, flags="C_CONTIGUOUS"
+        ),  # np_int64 *center_y
+        np.ctypeslib.ndpointer(
+            dtype=np.int64, ndim=1, flags="C_CONTIGUOUS"
+        ),  # np_int64 *center_x
+        np.ctypeslib.ndpointer(
+            dtype=np.float64, ndim=1, flags="C_CONTIGUOUS"
+        ),  # np_float64 *params
+        np.ctypeslib.ndpointer(
+            dtype=np.int64, ndim=1, flags="C_CONTIGUOUS"
+        ),  # np_int64 *fail
+    ]
+    lib.fit_array_of_gauss_2d_on_float_image.restpye = ctypes.c_int
+
+    _lib_gauss_2d = lib
+    return lib

--- a/plaster/tools/gauss2d/zests/zest_gauss2d.py
+++ b/plaster/tools/gauss2d/zests/zest_gauss2d.py
@@ -1,0 +1,181 @@
+from zest import zest
+import numpy as np
+from plaster.tools.image import imops
+from plaster.tools.gauss2d import gauss2d
+from plaster.run.sigproc_v2 import synth
+from plaster.tools.log.log import debug
+
+
+def _dump_params(params):
+    print("".join([f"{p:3.4f} " for p in params]))
+
+
+def zest_run_gauss_2_fit_on_synthetic():
+    raise NotImplementedError
+
+    # TODO More to do here, plus I'd like to get a timing
+
+    lib = gauss2d.load_lib()
+
+    with synth.Synth() as s:
+        peaks = (
+            synth.PeaksModelGaussianCircular(n_peaks=100)
+            .locs_grid()
+            .widths_uniform(1.8)
+            .amps_constant(val=6000)
+        )
+        synth.CameraModel(bias=0, std=10)
+        im = s.render_chcy()[0, 0].astype(np.float32)
+
+    # np.save("test.npy", im)
+
+    locs = np.array(peaks.locs)
+    cen_y = locs[:, 0].astype(int)
+    cen_x = locs[:, 1].astype(int)
+
+    mea = 9
+    y = int(cen_y[0])
+    x = int(cen_x[0])
+    _im = im[y - 4 : y + 5, x - 4 : x + 5]
+
+    n_peaks = peaks.n_peaks
+    n_peaks = 1  # HACK
+    params = np.zeros(
+        (n_peaks, 7)
+    )  # (amplitude, sigma_x, sigma_y, pos_x, pos_y, rho, offset)
+    fails = np.zeros((n_peaks,), dtype=int)
+
+    params[:, 0] = 1010.0
+    params[:, 1] = peaks.std_x[0:n_peaks]
+    params[:, 2] = peaks.std_y[0:n_peaks]
+    params[:, 3] = mea / 2
+    params[:, 4] = mea / 2
+    params[:, 5] = 0.0
+    params[:, 6] = 0.0
+
+    params = params.flatten()
+
+    n_fails = lib.fit_array_of_gauss_2d_on_float_image(
+        im, im.shape[0], im.shape[1], mea, n_peaks, cen_y, cen_x, params, fails,
+    )
+
+    print(f"n_peaks={n_peaks}")
+    print(f"n_fails={n_fails}")
+    print(params[0:7])
+    print(fails[0])
+
+    zest()
+
+
+def zest_gauss_2_fit():
+    lib = gauss2d.load_lib()
+
+    mea = 9
+
+    def _peak():
+        true_params = (
+            1000.0,  # amp
+            1.8,  # sig_y
+            1.2,  # sig_x
+            5.0,  # pos_y
+            4.8,  # pos_x
+            0.05,  # rho
+            50.0,  # offset
+        )
+
+        im = imops.gauss2_rho_form(
+            true_params[0],
+            true_params[2],  # Note reversed index
+            true_params[1],
+            true_params[4],  # Note reversed index
+            true_params[3],
+            true_params[5],
+            true_params[6],
+            mea,
+        ).flatten()
+
+        im = im + np.random.normal(0, 0.1, im.shape)
+
+        # Perturb the parameters
+        fit_params = np.array(
+            [
+                1010.0,  # amp
+                1.9,  # sig_y
+                1.0,  # sig_x
+                5.1,  # pos_y
+                4.1,  # pos_x
+                0.00,  # rho
+                0.0,  # offset
+            ]
+        )
+
+        return im, true_params, fit_params
+
+    def it_fits_a_single_gauss_2d():
+        im, true_params, fit_params = _peak()
+        info = np.zeros((10,))
+        covar = np.zeros((7 * 7,))
+        failed = lib.fit_gauss_2d(im, mea, fit_params, info, covar)
+        assert failed == 0
+        assert np.allclose(fit_params, true_params, rtol=0.06)
+
+    def it_fits_one_peak_on_float_image():
+        im, true_params, fit_params = _peak()
+
+        info = np.zeros((10,))
+        covar = np.zeros((7 * 7,))
+        im = im.astype(np.float32).reshape((mea, mea))
+        bigger_im = np.zeros((512, 512), dtype=np.float32)
+        bigger_im[100 : 100 + mea, 100 : 100 + mea] = im
+        failed = lib.fit_gauss_2d_on_float_image(
+            bigger_im,
+            bigger_im.shape[0],
+            bigger_im.shape[1],
+            100 + mea // 2,
+            100 + mea // 2,
+            mea,
+            fit_params,
+            info,
+            covar,
+        )
+        assert failed == 0
+        assert np.allclose(fit_params, true_params, rtol=0.06)
+
+    def it_fits_array_of_gauss_2d_on_float_image():
+        im, true_params, fit_params = _peak()
+
+        im = im.astype(np.float32).reshape((mea, mea))
+
+        bigger_im = np.zeros((512, 512), dtype=np.float32)
+        bigger_im[100 : 100 + mea, 100 : 100 + mea] = im
+        bigger_im[200 : 200 + mea, 200 : 200 + mea] = im
+
+        cen_y = np.array([100, 200, 300], dtype=np.int64) + mea // 2
+        cen_x = np.array([100, 200, 300], dtype=np.int64) + mea // 2
+
+        n_peaks = 3
+        fit_params = np.tile(fit_params, n_peaks)
+
+        fails = np.zeros((n_peaks,), dtype=int)
+
+        n_fails = lib.fit_array_of_gauss_2d_on_float_image(
+            bigger_im,
+            bigger_im.shape[0],
+            bigger_im.shape[1],
+            mea,
+            n_peaks,
+            cen_y,
+            cen_x,
+            fit_params,
+            fails,
+        )
+        assert n_fails == 1
+
+        fit_params = fit_params.reshape((n_peaks, 7))
+        fit_params[fails == 1, :] = np.nan
+
+        assert np.allclose(fit_params[0], true_params, rtol=0.06)
+        assert np.allclose(fit_params[1], true_params, rtol=0.06)
+        assert np.all(np.isnan(fit_params[2]))
+
+    zest()

--- a/plaster/tools/log/log.py
+++ b/plaster/tools/log/log.py
@@ -325,7 +325,7 @@ def debug(*args):
                 ):
                     values += [
                         f"\n{green}{caller}{reset}"
-                        f"{yellow}{arg.shape}{reset}=\n{arg}\n"
+                        f"{yellow} {arg.dtype}{arg.shape}{reset}=\n{arg}\n"
                     ]
                 else:
                     values += [


### PR DESCRIPTION
This is work to get the C-based Levenberg Marquadt fitter.
It uses ctypes instead of cython which I lot a better and I think this can establish the beginning of a pattern for conversion of other cython components.
It uses source that I've put in to zsimpson/zbs.lmfits