### PR TITLE
Fix prep_params and some related zests

### DIFF
--- a/plaster/run/prep/prep_params.py
+++ b/plaster/run/prep/prep_params.py
@@ -46,20 +46,21 @@ class PrepParams(Params):
         # Try to normalize abundance values if provided. If abundance values are provided, do basic validation.
         # If no abundance values are provided, do nothing.
         # When a protein csv with no abundance columns is provided, it will come through as all nans
+        # Note that self.proteins is likely a list of Munches, but could be a list of dicts, so don't assume we can access items as attrs
 
         abundance_info_present = any(
-            hasattr(protein, "abundance")
-            and protein.abundance is not None
-            and not math.isnan(protein.abundance)
+            "abundance" in protein
+            and protein["abundance"] is not None
+            and not math.isnan(protein["abundance"])
             for protein in self.proteins
         )
 
         if abundance_info_present:
             abundance_criteria = [
-                (lambda protein: hasattr(protein, "abundance"), "Abundance missing"),
+                (lambda protein: "abundance" in protein, "Abundance missing"),
                 (
-                    lambda protein: protein.abundance >= 0
-                    if protein.abundance is not None
+                    lambda protein: protein["abundance"] >= 0
+                    if protein["abundance"] is not None
                     else True,
                     "Abundance must be greater than or equal to zero",
                 ),
@@ -68,11 +69,11 @@ class PrepParams(Params):
             if not self.ALLOW_NONES_AND_NANS_IN_ABUNDANCE:
                 abundance_criteria += [
                     (
-                        lambda protein: protein.abundance is not None,
+                        lambda protein: protein["abundance"] is not None,
                         "Abundance must not be None",
                     ),
                     (
-                        lambda protein: not math.isnan(protein.abundance),
+                        lambda protein: not math.isnan(protein["abundance"]),
                         "Abundance must not be NaN",
                     ),
                 ]
@@ -83,26 +84,26 @@ class PrepParams(Params):
                 # Check to make sure abundance passes criteria
                 for criteria_fn, msg in abundance_criteria:
                     if not criteria_fn(protein):
-                        abundance_value = getattr(protein, "abundance")
+                        abundance_value = protein.get("abundance")
                         raise SchemaValidationFailed(
-                            f"Protein {protein.name} has invalid abundance: {abundance_value} - {msg}"
+                            f"Protein {protein.get('name')} has invalid abundance: {abundance_value} - {msg}"
                         )
 
                 # Find min abundance value
-                if min_abundance is None or (
-                    protein.abundance < min_abundance and protein.abundance > 0
-                ):
-                    min_abundance = protein.abundance
+                if (
+                    min_abundance is None or protein["abundance"] < min_abundance
+                ) and protein["abundance"] > 0:
+                    min_abundance = protein["abundance"]
 
             if self.NORMALIZE_ABUNDANCE:
                 if min_abundance != 1:
                     log.info("abundance data is not normalized, normalizing.")
                     # normalize abundance by min value
                     for protein in self.proteins:
-                        if protein.abundance is not None:
-                            protein.abundance /= min_abundance
+                        if protein["abundance"] is not None:
+                            protein["abundance"] /= min_abundance
         else:
             # Abundance information is missing from all proteins
             # Set abudance to 1
             for protein in self.proteins:
-                protein.abundance = 1
+                protein["abundance"] = 1

--- a/plaster/run/prep/zests/zest_prep_params.py
+++ b/plaster/run/prep/zests/zest_prep_params.py
@@ -56,6 +56,12 @@ def zest_prep_params_validate():
                 proteins=[_fake_protein(10), _fake_protein(5), _fake_protein(0)]
             )
 
+    def it_allows_zeros_as_first_value_in_unnormalized_abundance_data():
+        with zest.mock(log.info) as m_log:
+            unnormalized_abundance_data_with_zeros = PrepParams(
+                proteins=[_fake_protein(0), _fake_protein(5), _fake_protein(10)]
+            )
+
     def it_doesnt_allow_none_in_abundance_data():
         with zest.raises():
             normalized_abundance_data = PrepParams(


### PR DESCRIPTION
Note that this encodes some newish assumptions about abundance data in the prep_result zests as well as the prep_params zest. In a previous PR I added validation code to prep_params that is more strict about what is allowed in abundance values (namely not allowing missing abundance values, unless none are provided, in which case we assume equal abundance). I also changed some prep_result tests to account for the abundance normalization that occurs now.