### PR TITLE
add c_common_(new,old) to sigproc_v2 compile cache checks

### DIFF
--- a/plaster/run/nn_v2/c/build.py
+++ b/plaster/run/nn_v2/c/build.py
@@ -1,5 +1,5 @@
-from plumbum import local, FG
 from plaster.tools.utils.utils import any_out_of_date
+from plumbum import FG, local
 
 
 def build(dst_folder, c_common_folder, flann_include_folder, flann_lib_folder):
@@ -22,7 +22,11 @@ def build(dst_folder, c_common_folder, flann_include_folder, flann_lib_folder):
             gcc[c_opts, src_name, "-o", target_o] & FG
         return target_o
 
-    common_include_files = [f"{c_common_folder}/c_common.h"]
+    common_include_files = [
+        f"{c_common_folder}/c_common.h",
+        f"{c_common_folder}/c_common_old.h",
+        f"{c_common_folder}/c_common_new.h",
+    ]
     nn_v2_o = build_c("nn_v2.c", common_include_files)
     c_common_o = build_c(f"{c_common_folder}/c_common.c", common_include_files)
 

--- a/plaster/run/sigproc_v2/c_gauss2_fitter/build.py
+++ b/plaster/run/sigproc_v2/c_gauss2_fitter/build.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
-from plumbum import local, FG
 from plaster.tools.utils.utils import any_out_of_date
+from plumbum import FG, local
 
 
 def build(dst_folder, c_common_folder):
@@ -28,7 +28,11 @@ def build(dst_folder, c_common_folder):
             gcc[c_opts, src_name, "-o", target_o] & FG
         return target_o
 
-    common_include_files = [f"{c_common_folder}/c_common.h"]
+    common_include_files = [
+        f"{c_common_folder}/c_common.h",
+        f"{c_common_folder}/c_common_old.h",
+        f"{c_common_folder}/c_common_new.h",
+    ]
     gauss2_fitter_o = build_c("gauss2_fitter.c", common_include_files)
     c_common_o = build_c(f"{c_common_folder}/c_common.c", common_include_files)
 

--- a/plaster/run/sigproc_v2/c_radiometry/build.py
+++ b/plaster/run/sigproc_v2/c_radiometry/build.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
-from plumbum import local, FG
 from plaster.tools.utils.utils import any_out_of_date
+from plumbum import FG, local
 
 
 def build(dst_folder, c_common_folder):
@@ -30,7 +30,12 @@ def build(dst_folder, c_common_folder):
             gcc[c_opts, src_name, "-o", target_o] & FG
         return target_o
 
-    include_files = (f"{c_common_folder}/c_common.h", f"./csa_spline/csa.h")
+    include_files = (
+        f"{c_common_folder}/c_common.h",
+        f"{c_common_folder}/c_common_old.h",
+        f"{c_common_folder}/c_common_new.h",
+        f"./csa_spline/csa.h",
+    )
     radiometry_o = build_c("radiometry.c", include_files)
     c_common_o = build_c(f"{c_common_folder}/c_common.c", include_files)
     csa_o = build_c("./csa_spline/csa.c")

--- a/plaster/run/sigproc_v2/c_sub_pixel_align/build.py
+++ b/plaster/run/sigproc_v2/c_sub_pixel_align/build.py
@@ -22,7 +22,11 @@ def build(dst_folder, c_common_folder):
             gcc[c_opts, src_name, "-o", target_o] & FG
         return target_o
 
-    common_include_files = [f"{c_common_folder}/c_common.h"]
+    common_include_files = [
+        f"{c_common_folder}/c_common.h",
+        f"{c_common_folder}/c_common_old.h",
+        f"{c_common_folder}/c_common_new.h",
+    ]
     sub_pixel_align_o = build_c(f"{dst_folder}/sub_pixel_align.c", common_include_files)
     c_common_o = build_c(f"{c_common_folder}/c_common.c", common_include_files)
 


### PR DESCRIPTION
c_common_old.h and c_common_new.h aren't checked as part of the compile cache logic, so your suspicion that build.py's aren't looking at the headers is correct, and is probably the reason he's hitting the error. 

I wasn't able to repro it however, so I'm also going to recommend that Nava rebuild his container.

I'll consider refactoring/DRYing out some of this code when I'm working on ripping out cython.